### PR TITLE
Fix/#1/refatorar responsabilidade rabbitmq

### DIFF
--- a/Domain/Log/Services/LogService.php
+++ b/Domain/Log/Services/LogService.php
@@ -5,6 +5,7 @@ namespace Domain\Log\Services;
 use Domain\Log\DTO\LogDTO;
 use Domain\Log\Interfaces\ILog;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Message\AMQPMessage;
 
 require_once 'vendor\autoload.php';
 
@@ -29,5 +30,29 @@ class LogService
         $logDTO->setMensagem(explode('=', $response[1])[1]);
 
         $this->logRepository->cadastro($logDTO);
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function logCadastroUsuario(string $data, string $queue): void {
+        $conexaoMensageria = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+        $canal = $conexaoMensageria->channel();
+
+        match($queue) {
+            'cadastroUsuario' => $canal->queue_declare('cadastroUsuario', false, true, false, false)
+        };
+
+        $msg = new AMQPMessage(
+            $data,
+            array('delivery_mode' => AMQPMessage::DELIVERY_MODE_PERSISTENT)
+        );
+
+        match($queue) {
+            'cadastroUsuario' => $canal->basic_publish($msg, '', 'cadastroUsuario')
+        };
+
+        $canal->close();
+        $conexaoMensageria->close();
     }
 }

--- a/app/providers/Container.php
+++ b/app/providers/Container.php
@@ -56,7 +56,9 @@ class Container
             if ($nomeClasse == 'CadastroController') {
                 $cadastroRequest = $this->resolve('CadastroRequest');
                 $usuarioService = $this->resolve('UsuarioService');
-                return new $classeConcreta($cadastroRequest, $usuarioService);
+                $logService = $this->resolve('LogService');
+                $envioEmailService = $this->resolve('EnvioEmailService');
+                return new $classeConcreta($cadastroRequest, $usuarioService, $logService, $envioEmailService);
             }
             if ($nomeClasse == 'LoginController') {
                 $loginRequest = $this->resolve('LoginRequest');


### PR DESCRIPTION
O que foi feito:

1. Retirei os dois metodos do `CadastroController`: `envioEmail` e `logCadastroUsuario`.
2. Dentro do service `EnvioEmailService`, inseri o método `envioEmail` e alterei modificador de acesso do método de `private` para `public`, alterei os parametros do método para receber `string $data` e `string $queue`, onde, respectivamente são, o que vai ser passado para o consumer e nome da queue. Inseri no uso dos métodos `queue_declare` e `basic_publish` um `match condition` baseado no valor de `queue` para maior escalabilidade do código.
3. Dentro do service `LogService` basicamente foi feito a mesma coisa que o do EnvioEmailService, porém, com o método `logCadastroUsuario`
4. Foi registrado a depêndencia dessas classes para o construtor de `CadastroController`